### PR TITLE
Sped up live-image page

### DIFF
--- a/src/lib/server/nina.ts
+++ b/src/lib/server/nina.ts
@@ -255,6 +255,10 @@ export class NinaClient {
     }
     return this.cachedLiveImage;
   }
+
+  haveImage() {
+    return !!this.cachedLiveImage;
+  }
 }
 
 export const nina = new NinaClient();

--- a/src/routes/[[lang=lang]]/live-photo/+page.server.ts
+++ b/src/routes/[[lang=lang]]/live-photo/+page.server.ts
@@ -4,13 +4,11 @@ import type { PageServerLoad } from './$types';
 export const load = (async ({ parent, url }) => {
   const data = await parent();
 
-  const img = await nina.getLiveImage();
-
   return {
     meta: {
       title: data.lang.live_photo.title,
       description: data.lang.live_photo.description,
-      image: img ? `${url.origin}/api/live-image` : undefined
+      image: nina.haveImage() ? `${url.origin}/api/live-image` : undefined
     }
   };
 }) satisfies PageServerLoad;


### PR DESCRIPTION
Currently the live-image page was waiting for the response of get-image, meaning, that person clicked the page, and he must wait like 5 second to for example timeout... This change, only check condition, and directly open page.